### PR TITLE
feat: Implement Acadiana flag color theme

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -16,9 +16,53 @@ export interface ButtonProps extends ChakraButtonProps, ButtonLoadingProps {}
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   function Button(props, ref) {
-    const { loading, disabled, loadingText, children, ...rest } = props;
+    const { loading, disabled, loadingText, children, variant, ...rest } = props;
+
+    // Default styles for solid variant (or if no variant is specified)
+    let styleProps: ChakraButtonProps = {
+      bg: 'acadianaGold.500',
+      color: 'black', // Ensure high contrast with acadianaGold.500
+      _hover: {
+        bg: 'acadianaGold.700',
+      },
+      _focus: {
+        bg: 'acadianaGold.700',
+        boxShadow: 'outline', // Or a specific shadow for gold
+      },
+    };
+
+    if (variant === 'outline') {
+      styleProps = {
+        variant: 'outline',
+        borderColor: 'acadianaGold.500',
+        color: 'acadianaGold.700',
+        _hover: {
+          bg: 'acadianaGold.100',
+        },
+      };
+    } else if (variant === 'ghost') {
+      styleProps = {
+        variant: 'ghost',
+        color: 'acadianaGold.700',
+        _hover: {
+          bg: 'acadianaGold.100',
+        },
+      };
+    }
+    
+    // Common properties for all variants when disabled
+    const disabledStyles = {
+      _hover: {}, // No hover effect when disabled
+    };
+
     return (
-      <ChakraButton disabled={loading || disabled} ref={ref} {...rest}>
+      <ChakraButton
+        disabled={loading || disabled}
+        ref={ref}
+        {...styleProps} // Apply determined styles
+        {...(loading || disabled ? disabledStyles : {})} // Override hover if disabled
+        {...rest} // Spread remaining props (like onClick, size, etc.)
+      >
         {loading && !loadingText ? (
           <>
             <AbsoluteCenter display="inline-flex">

--- a/src/components/ui/events.tsx
+++ b/src/components/ui/events.tsx
@@ -78,6 +78,8 @@ export const EventsCalendar = () => {
                 alignItems="center"
                 gap={2}
                 mb={2}
+                color="acadianaBlue.700"
+                _hover={{ color: 'acadianaRed.500' }}
               >
                 <FaExternalLinkAlt /> {event.tournament_name}
               </Link>
@@ -110,13 +112,14 @@ export const EventsCalendar = () => {
                   display="flex"
                   alignItems="center"
                   gap="6px"
-                  _hover={{ textDecoration: 'underline' }}
+                  color="acadianaBlue.700"
+                  _hover={{ color: 'acadianaRed.500', textDecoration: 'none' }}
                   style={{ fontWeight: 'bold' }}
                 >
                   <FaExternalLinkAlt style={{ marginBottom: '2px' }} />
                   {event.tournament_name}
                 </Link>
-                <div style={{ fontSize: '0.85rem', color: '#555' }}>
+                <div style={{ fontSize: '0.85rem', color: 'var(--chakra-colors-gray-600)' }}>
                   {formatDate(event.event_start_date)}
                 </div>
               </td>

--- a/src/components/ui/leaderboard.tsx
+++ b/src/components/ui/leaderboard.tsx
@@ -62,28 +62,29 @@ export const LouisianaStandings = () => {
   }
   return (
     <Table.ScrollArea borderWidth="1px" rounded="md" maxHeight="40vh">
-      <Table.Root size="md" stickyHeader striped colorPalette={'orange'}>
+      <Table.Root size="md" stickyHeader striped>
         <Table.Caption>
           Source:{' '}
           <Link
             href="https://www.ifpapinball.com/series/nacs/2025/standingsView.php?l=LA"
-            _hover={{ textDecoration: 'underline' }}
+            color="acadianaBlue.700"
+            _hover={{ color: 'acadianaRed.500', textDecoration: 'none' }}
           >
             IFPA NACS Standings LA
           </Link>
         </Table.Caption>
         <Table.Header>
           <Table.Row bg="bg.emphasized">
-            <Table.ColumnHeader fontWeight={'bold'}>Player</Table.ColumnHeader>
-            <Table.ColumnHeader fontWeight={'bold'}>Rank</Table.ColumnHeader>
-            <Table.ColumnHeader fontWeight={'bold'}>WPPRs</Table.ColumnHeader>
+            <Table.ColumnHeader fontWeight={'bold'} color="acadianaBlue.700">Player</Table.ColumnHeader>
+            <Table.ColumnHeader fontWeight={'bold'} color="acadianaBlue.700">Rank</Table.ColumnHeader>
+            <Table.ColumnHeader fontWeight={'bold'} color="acadianaBlue.700">WPPRs</Table.ColumnHeader>
           </Table.Row>
         </Table.Header>
 
         <Table.Body>
           {standings.map((standing) => (
             <Table.Row key={standing.player_id}>
-              <Table.Cell>{standing.player_name}</Table.Cell>
+              <Table.Cell color="acadianaGold.700">{standing.player_name}</Table.Cell>
               <Table.Cell>{standing.series_rank}</Table.Cell>
               <Table.Cell>{standing.wppr_points}</Table.Cell>
             </Table.Row>

--- a/src/lib/layout/components/footer.tsx
+++ b/src/lib/layout/components/footer.tsx
@@ -11,12 +11,12 @@ export const Footer = () => {
       gap={2}
     >
       <Link href="https://www.facebook.com/share/g/1YMaMmKDid/">
-        <IconButton aria-label="Facebook" variant="ghost" size="md">
+        <IconButton aria-label="Facebook" variant="ghost" size="md" color="acadianaBlue.700">
           <FaFacebook />
         </IconButton>
       </Link>
       <Link href="https://www.instagram.com/acadianapinballplayers/">
-        <IconButton aria-label="Instagram" variant="ghost" size="md">
+        <IconButton aria-label="Instagram" variant="ghost" size="md" color="acadianaGold.700">
           <FaInstagram />
         </IconButton>
       </Link>

--- a/src/lib/layout/components/header.tsx
+++ b/src/lib/layout/components/header.tsx
@@ -14,6 +14,7 @@ export const Header = () => {
           fontSize={['sm', 'md', 'xl', '3xl']}
           fontFamily="'Press Start 2P', sans-serif"
           textAlign={'center'}
+          color="acadianaBlue.700"
         >
           Acadiana Pinball Players
         </Heading>
@@ -33,16 +34,16 @@ export const Header = () => {
       </Flex>
 
       <Flex gap={6} display={{ base: 'none', md: 'flex' }}>
-        <Link href="/" _hover={{ textDecoration: 'underline' }}>
+        <Link href="/" color="acadianaBlue.700" _hover={{ color: 'acadianaRed.500' }}>
           Home
         </Link>
-        <Link href="/new-players" _hover={{ textDecoration: 'underline' }}>
+        <Link href="/new-players" color="acadianaBlue.700" _hover={{ color: 'acadianaRed.500' }}>
           New Players Guide
         </Link>
-        <Link href="/resources" _hover={{ textDecoration: 'underline' }}>
+        <Link href="/resources" color="acadianaBlue.700" _hover={{ color: 'acadianaRed.500' }}>
           Resources
         </Link>
-        <Link href="/about" _hover={{ textDecoration: 'underline' }}>
+        <Link href="/about" color="acadianaBlue.700" _hover={{ color: 'acadianaRed.500' }}>
           About
         </Link>
       </Flex>

--- a/src/lib/layout/index.tsx
+++ b/src/lib/layout/index.tsx
@@ -20,7 +20,7 @@ export const Layout = ({ children }: LayoutProps) => {
         boxShadow={'md'}
         margin="0 auto"
         borderBottom="2px solid"
-        borderColor="gray.200"
+        borderColor="acadianaRed.500"
         zIndex="10"
         pt={{ lg: 4 }}
       >
@@ -37,7 +37,7 @@ export const Layout = ({ children }: LayoutProps) => {
         margin="0 auto"
         pt={{ lg: 4 }}
         transition="0.5s ease-out"
-        bgColor="white"
+        bgColor="acadianaBlue.50"
         boxShadow="md"
       >
         {children}

--- a/src/lib/pages/home/index.tsx
+++ b/src/lib/pages/home/index.tsx
@@ -16,6 +16,7 @@ const Home = () => {
             textAlign={'center'}
             mb="2"
             fontSize={{ base: 'xl', lg: '2xl' }}
+            color="acadianaBlue.700"
           >
             Welcome!
           </Heading>
@@ -26,14 +27,14 @@ const Home = () => {
           </Text>
           <Text mb={2}>
             Not sure where to find pinball? Check out this handy{' '}
-            <Link variant="underline" href="https://pinballmap.com/">
+            <Link color="acadianaBlue.700" _hover={{ color: 'acadianaRed.500', textDecoration: 'none' }} href="https://pinballmap.com/">
               Pinball Map!
             </Link>
           </Text>
           <Text mb={2}>
             If you're a new player and unsure where to start in the competitive
             pinball scene, check out the{' '}
-            <Link variant="underline" href="/new-players">
+            <Link color="acadianaBlue.700" _hover={{ color: 'acadianaRed.500', textDecoration: 'none' }} href="/new-players">
               new player guide.
             </Link>
           </Text>
@@ -41,7 +42,8 @@ const Home = () => {
           <Text mb={2}>
             Be sure to join the{' '}
             <Link
-              variant="underline"
+              color="acadianaBlue.700"
+              _hover={{ color: 'acadianaRed.500', textDecoration: 'none' }}
               href="https://www.facebook.com/share/g/1PCVbjN6A1/"
             >
               Acadiana Pinball Players Facebook Group
@@ -70,6 +72,7 @@ const Home = () => {
             textAlign={'center'}
             mb="2"
             fontSize={{ base: 'xl', lg: '2xl' }}
+            color="acadianaBlue.700"
           >
             Upcoming Events
           </Heading>
@@ -80,6 +83,7 @@ const Home = () => {
             textAlign={'center'}
             mb="2"
             fontSize={{ base: 'xl', lg: '2xl' }}
+            color="acadianaBlue.700"
           >
             🏆 {new Date().getFullYear()} Louisiana Leaderboard 🏆
           </Heading>

--- a/src/lib/styles/theme/index.ts
+++ b/src/lib/styles/theme/index.ts
@@ -7,6 +7,23 @@ export const theme = createSystem(defaultConfig, {
         heading: { value: 'Plus Jakarta Sans Variable, sans-serif' },
         body: { value: 'Plus Jakarta Sans Variable, sans-serif' },
       },
+      colors: {
+        acadianaBlue: {
+          100: '#E6E8F0',
+          500: '#00205B',
+          700: '#00102D',
+        },
+        acadianaRed: {
+          100: '#FDE9E8',
+          500: '#DA291C',
+          700: '#6D150E',
+        },
+        acadianaGold: {
+          100: '#FFF8E1',
+          500: '#FFC72C',
+          700: '#B38B1F',
+        },
+      },
     },
   },
 });

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -29,13 +29,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        <Global
-          styles={{
-            body: {
-              backgroundColor: '#f4a261',
-            },
-          }}
-        />
+        <Global />
         <HelmetProvider>
           <Provider>
             <AppLayout>{children}</AppLayout>


### PR DESCRIPTION
This commit updates the website's color scheme to reflect the colors of the Acadiana flag: blue, red, and gold, with white as a primary background.

Key changes include:
- Defined `acadianaBlue`, `acadianaRed`, and `acadianaGold` color palettes in the Chakra UI theme configuration (`src/lib/styles/theme/index.ts`).
- Updated the main layout background to a light `acadianaBlue.50`.
- Styled headers, footers, and navigation links with `acadianaBlue` and `acadianaRed` accents.
- Re-themed buttons to use `acadianaGold` as the primary call-to-action color, ensuring high text contrast.
- Applied theme colors to UI components such as events, leaderboards, and specific home page elements for a consistent look and feel.
- Maintained readability and visual hierarchy with the new color scheme.